### PR TITLE
Added AST structure, AST parser, AST viewer and related tests

### DIFF
--- a/SproutLang/AST/AST.cs
+++ b/SproutLang/AST/AST.cs
@@ -1,0 +1,6 @@
+namespace SproutLang.AST;
+
+public abstract class AST
+{
+    
+}

--- a/SproutLang/AST/ArgList.cs
+++ b/SproutLang/AST/ArgList.cs
@@ -1,0 +1,11 @@
+namespace SproutLang.AST;
+
+public class ArgList: AST
+{
+    public List<Expression> Arguments { get; }
+    
+    public ArgList()
+    {
+        Arguments = new List<Expression>();
+    }
+}

--- a/SproutLang/AST/ArrayAssigment.cs
+++ b/SproutLang/AST/ArrayAssigment.cs
@@ -1,0 +1,12 @@
+namespace SproutLang.AST;
+
+public class ArrayAssigment: LValue
+{
+    public Identifier Name;
+    public Expression Index;
+    public ArrayAssigment(Identifier name, Expression index)
+    {
+        Name = name;
+        Index = index;
+    }
+}

--- a/SproutLang/AST/ArrayAssignment.cs
+++ b/SproutLang/AST/ArrayAssignment.cs
@@ -1,10 +1,10 @@
 namespace SproutLang.AST;
 
-public class ArrayAssigment: LValue
+public class ArrayAssignment: LValue
 {
     public Identifier Name;
     public Expression Index;
-    public ArrayAssigment(Identifier name, Expression index)
+    public ArrayAssignment(Identifier name, Expression index)
     {
         Name = name;
         Index = index;

--- a/SproutLang/AST/BaseType.cs
+++ b/SproutLang/AST/BaseType.cs
@@ -1,0 +1,8 @@
+namespace SproutLang.AST;
+
+public enum BaseType
+{
+    Int,
+    Bool,
+    Char,
+}

--- a/SproutLang/AST/BinaryExpr.cs
+++ b/SproutLang/AST/BinaryExpr.cs
@@ -1,0 +1,14 @@
+namespace SproutLang.AST;
+
+public class BinaryExpr: Expression
+{
+    public Expression left { get; }
+    public Operator op { get; }
+    public Expression right { get; }
+    public BinaryExpr(Expression left, Operator op, Expression right)
+    {
+        this.left = left;
+        this.op = op;
+        this.right = right;
+    }
+}

--- a/SproutLang/AST/Block.cs
+++ b/SproutLang/AST/Block.cs
@@ -1,0 +1,12 @@
+namespace SproutLang.AST;
+
+public sealed class Block : AST
+{
+
+    public List<Statement> Statements { get; }
+
+    public Block(List<Statement> statements)
+    {
+        Statements = statements;
+    }
+}

--- a/SproutLang/AST/BoolLiteral.cs
+++ b/SproutLang/AST/BoolLiteral.cs
@@ -1,0 +1,11 @@
+namespace SproutLang.AST;
+
+public class BoolLiteral: Terminal
+{
+    public bool Value { get; }
+    
+    public BoolLiteral(bool value) : base(value.ToString().ToLower())
+    {
+        Value = value;
+    }
+}

--- a/SproutLang/AST/BoolLiteralExpression.cs
+++ b/SproutLang/AST/BoolLiteralExpression.cs
@@ -1,0 +1,11 @@
+namespace SproutLang.AST;
+
+public class BoolLiteralExpression: Expression
+{
+    public BoolLiteral Literal { get; }
+    
+    public BoolLiteralExpression(BoolLiteral literal)
+    {
+        Literal = literal;
+    }
+}

--- a/SproutLang/AST/CallExpr.cs
+++ b/SproutLang/AST/CallExpr.cs
@@ -1,0 +1,14 @@
+namespace SproutLang.AST;
+
+public class CallExpr:  Expression
+{
+    public string Callee { get; }
+    public ArgList Arguments { get; }
+
+    public CallExpr(string callee, ArgList arguments)
+    {
+        Callee = callee;
+        Arguments = arguments;
+    }
+    
+}

--- a/SproutLang/AST/CallStatement.cs
+++ b/SproutLang/AST/CallStatement.cs
@@ -1,0 +1,11 @@
+namespace SproutLang.AST;
+
+public class CallStatement: Statement
+{
+    public CallExpr Call { get; }
+
+    public CallStatement(CallExpr call)
+    {
+        Call = call;
+    }
+}

--- a/SproutLang/AST/CharLiteral.cs
+++ b/SproutLang/AST/CharLiteral.cs
@@ -1,0 +1,11 @@
+namespace SproutLang.AST;
+
+public class CharLiteral : Terminal
+{
+    public char Value { get; }
+    public CharLiteral(char value) : base(value.ToString())
+    {
+        Value = value;
+    }
+    
+}

--- a/SproutLang/AST/CharLiteralExpression.cs
+++ b/SproutLang/AST/CharLiteralExpression.cs
@@ -1,0 +1,11 @@
+namespace SproutLang.AST;
+
+public class CharLiteralExpression: Expression
+{
+    public CharLiteral Literal { get; }
+
+    public CharLiteralExpression(CharLiteral literal)
+    {
+        Literal = literal;
+    } 
+}

--- a/SproutLang/AST/Declaration.cs
+++ b/SproutLang/AST/Declaration.cs
@@ -1,0 +1,5 @@
+namespace SproutLang.AST;
+
+public class Declaration :  Statement
+{
+}

--- a/SproutLang/AST/Expression.cs
+++ b/SproutLang/AST/Expression.cs
@@ -1,0 +1,6 @@
+namespace SproutLang.AST;
+
+public class Expression :  AST
+{
+    
+}

--- a/SproutLang/AST/Identifier.cs
+++ b/SproutLang/AST/Identifier.cs
@@ -1,0 +1,8 @@
+namespace SproutLang.AST;
+
+public class Identifier : Terminal
+{
+    public Identifier(string spelling) : base(spelling)
+    {
+    }
+}

--- a/SproutLang/AST/IfBranch.cs
+++ b/SproutLang/AST/IfBranch.cs
@@ -1,0 +1,12 @@
+namespace SproutLang.AST;
+
+public sealed class IfBranch: AST
+{
+    public Expression Condition {get;}
+    public Block Block {get;}
+    public IfBranch(Expression condition, Block block)
+    {
+        Condition = condition;
+        Block = block;
+    }
+}

--- a/SproutLang/AST/IfStatement.cs
+++ b/SproutLang/AST/IfStatement.cs
@@ -1,0 +1,15 @@
+namespace SproutLang.AST;
+
+public class IfStatement: Statement
+{
+    public IfBranch First { get; }
+    public List<IfBranch> ElseIfBranches { get; }
+    public Block? ElseBlock { get; }
+    
+    public IfStatement(IfBranch first, List<IfBranch> elseIfBranches, Block? elseBlock)
+    {
+        First = first;
+        ElseIfBranches = elseIfBranches;
+        ElseBlock = elseBlock;
+    }
+}

--- a/SproutLang/AST/IntLiteral.cs
+++ b/SproutLang/AST/IntLiteral.cs
@@ -1,0 +1,10 @@
+namespace SproutLang.AST;
+
+public class IntLiteral:  Terminal
+{
+    public int Value { get; }
+    public IntLiteral(int value) : base(value.ToString())
+    {
+        Value = value;
+    }
+}

--- a/SproutLang/AST/IntLiteralExpression.cs
+++ b/SproutLang/AST/IntLiteralExpression.cs
@@ -2,9 +2,9 @@ namespace SproutLang.AST;
 
 public class IntLiteralExpression: Expression
 {
-    public IntLiteral Lieteral { get; }
-    public IntLiteralExpression(IntLiteral lieteral)
+    public IntLiteral Literal { get; }
+    public IntLiteralExpression(IntLiteral literal)
     {
-        Lieteral = lieteral;
+        Literal = literal;
     }
 }

--- a/SproutLang/AST/IntLiteralExpression.cs
+++ b/SproutLang/AST/IntLiteralExpression.cs
@@ -1,0 +1,10 @@
+namespace SproutLang.AST;
+
+public class IntLiteralExpression: Expression
+{
+    public IntLiteral Lieteral { get; }
+    public IntLiteralExpression(IntLiteral lieteral)
+    {
+        Lieteral = lieteral;
+    }
+}

--- a/SproutLang/AST/LValue.cs
+++ b/SproutLang/AST/LValue.cs
@@ -1,0 +1,6 @@
+namespace SproutLang.AST;
+
+public abstract class LValue: Statement
+{
+    
+}

--- a/SproutLang/AST/ListenStatement.cs
+++ b/SproutLang/AST/ListenStatement.cs
@@ -1,0 +1,10 @@
+namespace SproutLang.AST;
+
+public class ListenStatement: Statement
+{
+    public Identifier Identifier;
+    public ListenStatement(Identifier identifier)
+    {
+        Identifier = identifier;
+    }
+}

--- a/SproutLang/AST/LoopStatement.cs
+++ b/SproutLang/AST/LoopStatement.cs
@@ -1,0 +1,6 @@
+namespace SproutLang.AST;
+
+public abstract class LoopStatement: Statement
+{
+    
+}

--- a/SproutLang/AST/Operator.cs
+++ b/SproutLang/AST/Operator.cs
@@ -1,0 +1,8 @@
+namespace SproutLang.AST;
+
+public class Operator: Terminal
+{
+    public Operator(string spelling) : base(spelling)
+    {
+    }
+}

--- a/SproutLang/AST/Param.cs
+++ b/SproutLang/AST/Param.cs
@@ -1,0 +1,12 @@
+namespace SproutLang.AST;
+
+public class Param :AST
+{
+    public TypeSpec Type { get; }
+    public Identifier Name { get; }
+    public Param(TypeSpec type, Identifier name)
+    {
+        Type = type;
+        Name = name;
+    }
+}

--- a/SproutLang/AST/Program.cs
+++ b/SproutLang/AST/Program.cs
@@ -1,0 +1,11 @@
+namespace SproutLang.AST;
+
+public class Program: AST
+{
+    public Block Block { get; }
+    
+    public Program(Block block)
+    {
+        Block = block;
+    }
+}

--- a/SproutLang/AST/RepeatTimes.cs
+++ b/SproutLang/AST/RepeatTimes.cs
@@ -1,0 +1,15 @@
+using System.Reflection.Metadata;
+
+namespace SproutLang.AST;
+
+public class RepeatTimes: LoopStatement
+{
+    public int Times {get;}
+    public Block Body {get;}
+    
+    public RepeatTimes(int times, Block body)
+    {
+        Times = times;
+        Body = body;
+    }
+}

--- a/SproutLang/AST/RepeatTimes.cs
+++ b/SproutLang/AST/RepeatTimes.cs
@@ -1,5 +1,3 @@
-using System.Reflection.Metadata;
-
 namespace SproutLang.AST;
 
 public class RepeatTimes: LoopStatement

--- a/SproutLang/AST/RepeatUntil.cs
+++ b/SproutLang/AST/RepeatUntil.cs
@@ -1,0 +1,12 @@
+namespace SproutLang.AST;
+
+public class RepeatUntil: LoopStatement
+{
+    public Expression Condition {get;}
+    public Block Body {get;}
+    public RepeatUntil(Expression condition, Block body)
+    {
+        Condition = condition;
+        Body = body;
+    }
+}

--- a/SproutLang/AST/SimpleType.cs
+++ b/SproutLang/AST/SimpleType.cs
@@ -1,0 +1,7 @@
+namespace SproutLang.AST;
+
+public class SimpleType : TypeSpec
+{
+    public BaseType Kind { get; }
+    public SimpleType(BaseType kind) => Kind = kind;
+}

--- a/SproutLang/AST/Statement.cs
+++ b/SproutLang/AST/Statement.cs
@@ -1,0 +1,6 @@
+namespace SproutLang.AST;
+
+public class Statement : AST
+{
+    
+}

--- a/SproutLang/AST/SubRoutineDeclar.cs
+++ b/SproutLang/AST/SubRoutineDeclar.cs
@@ -1,0 +1,15 @@
+namespace SproutLang.AST;
+
+public sealed class SubRoutineDeclar : Statement
+{
+    public Identifier Name { get; }
+    public List<Param> Params { get; }
+    public Block Body { get; }
+
+    public SubRoutineDeclar(Identifier name, List<Param> parameters, Block body)
+    {
+        Name = name;
+        Params = parameters;
+        Body = body;
+    }
+}

--- a/SproutLang/AST/Terminal.cs
+++ b/SproutLang/AST/Terminal.cs
@@ -1,0 +1,11 @@
+namespace SproutLang.AST;
+
+public abstract class Terminal : AST
+{
+    public string Spelling { get; }
+
+    protected Terminal(string spelling)
+    {
+        Spelling = spelling;
+    }
+}

--- a/SproutLang/AST/TypeSpec.cs
+++ b/SproutLang/AST/TypeSpec.cs
@@ -1,0 +1,6 @@
+namespace SproutLang.AST;
+
+public abstract class TypeSpec: AST
+{
+    
+}

--- a/SproutLang/AST/UnaryExpr.cs
+++ b/SproutLang/AST/UnaryExpr.cs
@@ -1,0 +1,12 @@
+namespace SproutLang.AST;
+
+public class UnaryExpr : Expression
+{
+    public Operator Operator;
+    public Expression Operand;
+    public UnaryExpr(Operator op, Expression operand)
+    {
+        Operator = op;
+        Operand = operand;
+    }
+}

--- a/SproutLang/AST/VarAssignment.cs
+++ b/SproutLang/AST/VarAssignment.cs
@@ -1,0 +1,13 @@
+namespace SproutLang.AST;
+
+public class VarAssignment: LValue
+{
+    public Identifier Name { get; }
+    public Expression Expr { get; }
+
+    public VarAssignment(Identifier name, Expression expr)
+    {
+        Name = name;
+        Expr = expr;
+    }
+}

--- a/SproutLang/AST/VarDecl.cs
+++ b/SproutLang/AST/VarDecl.cs
@@ -1,0 +1,13 @@
+namespace SproutLang.AST;
+
+public sealed class VarDecl :  Declaration
+{
+    public TypeSpec Type { get; }
+    public Identifier Name { get; }
+
+    public VarDecl(TypeSpec type, Identifier identifier)
+    {
+        Type = type;
+        Name = identifier;
+    }
+}

--- a/SproutLang/AST/VarExpression.cs
+++ b/SproutLang/AST/VarExpression.cs
@@ -1,0 +1,11 @@
+namespace SproutLang.AST;
+
+public sealed class VarExpression: Expression
+{
+    public Identifier Name { get; }
+
+    public VarExpression(Identifier name)
+    {
+        Name = name;
+    }
+}

--- a/SproutLang/AST/VomitStatement.cs
+++ b/SproutLang/AST/VomitStatement.cs
@@ -1,0 +1,11 @@
+namespace SproutLang.AST;
+
+public class VomitStatement: Statement
+{
+    public Expression Expression { get; }
+    public VomitStatement(Expression expression)
+    {
+        Expression = expression;
+    }
+    
+}

--- a/SproutLang/Parser/ASTParser.cs
+++ b/SproutLang/Parser/ASTParser.cs
@@ -1,0 +1,448 @@
+using SproutLang.Scanner;
+using SproutLang.AST;
+
+namespace SproutLang.Parser;
+
+public class ASTParser
+{
+    private readonly Scanner.Scanner _scanner;
+    private Token _currentToken;
+
+    public ASTParser(Scanner.Scanner scanner)
+    {
+        _scanner = scanner;
+        _currentToken = _scanner.Scan();
+    }
+
+    private void Accept(TokenKind expectedKind)
+    {
+        if (_currentToken.Kind == expectedKind)
+        {
+            _currentToken = _scanner.Scan();
+        }
+        else
+        {
+            throw new Exception($"Expected {expectedKind}, but found {_currentToken.Kind}");
+        }
+    }
+
+    public AST.Program ParseProgram()
+    {
+        var statements = new List<Statement>();
+
+        while (IsStarterOfStatement(_currentToken.Kind))
+        {
+            statements.Add(ParseOneStatement());
+        }
+
+        return new AST.Program(new Block(statements));
+    }
+
+    private Statement ParseOneStatement()
+    {
+        return _currentToken.Kind switch
+        {
+            TokenKind.Create => ParseDeclaration(),
+            TokenKind.Identifier => ParseAssignmentOrCall(),
+            TokenKind.Si => ParseIfStatement(),
+            TokenKind.Repeat => ParseLoopStatement(),
+            TokenKind.Vomit => ParseVomitStatement(),
+            TokenKind.ListenCarefully => ParseListenStatement(),
+            TokenKind.Sprout => ParseSubroutineDecl(),
+            TokenKind.Bloom => ParseCallStatement(),
+            _ => throw new Exception($"Unexpected token: {_currentToken.Kind}")
+        };
+    }
+
+    private VarDecl ParseDeclaration()
+    {
+        Accept(TokenKind.Create);
+
+        TypeSpec type;
+        Identifier name;
+
+        if (_currentToken.Kind == TokenKind.LBracket)
+        {
+            Accept(TokenKind.LBracket);
+            type = ParseType();
+            Accept(TokenKind.Comma);
+            Accept(TokenKind.IntLiteral); // size not stored in AST here
+            Accept(TokenKind.RBracket);
+        }
+        else
+        {
+            type = ParseType();
+        }
+
+        name = ParseIdentifier();
+        Accept(TokenKind.Assign);
+        ParseExpression(); // Initializer ignored for now
+        Accept(TokenKind.Semicolon);
+
+        return new VarDecl(type, name);
+    }
+
+    private Statement ParseAssignmentOrCall()
+    {
+        Identifier id = ParseIdentifier();
+
+        if (_currentToken.Kind == TokenKind.Assign)
+        {
+            Accept(TokenKind.Assign);
+            Expression expr = ParseExpression();
+            Accept(TokenKind.Semicolon);
+            return new VarAssignment(id, expr);
+        }
+        else if (_currentToken.Kind == TokenKind.LParenthesis)
+        {
+            Accept(TokenKind.LParenthesis);
+            var args = ParseArguments();
+            Accept(TokenKind.RParenthesis);
+            Accept(TokenKind.Semicolon);
+            return new CallStatement(new CallExpr(id.Spelling, args));
+        }
+        else
+        {
+            throw new Exception("Invalid assignment or call.");
+        }
+    }
+
+    private IfStatement ParseIfStatement()
+    {
+        Accept(TokenKind.Si);
+        Accept(TokenKind.LParenthesis);
+        Expression condition = ParseExpression();
+        Accept(TokenKind.RParenthesis);
+        Block thenBlock = ParseBlock();
+
+        var first = new IfBranch(condition, thenBlock);
+        
+        var elseIfs = new List<IfBranch>();
+        while (_currentToken.Kind == TokenKind.O)
+        {
+            Accept(TokenKind.O);
+            Accept(TokenKind.Sino);
+            Accept(TokenKind.LParenthesis);
+            Expression elseIfCond = ParseExpression();
+            Accept(TokenKind.RParenthesis);
+            Block elseIfBlock = ParseBlock();
+            elseIfs.Add(new IfBranch(elseIfCond, elseIfBlock));
+        }
+
+        Block? elseBlock = null;
+        if (_currentToken.Kind == TokenKind.Sino)
+        {
+            Accept(TokenKind.Sino);
+            elseBlock = ParseBlock();
+        }
+
+        return new IfStatement(first, elseIfs, elseBlock);
+    }
+
+    private LoopStatement ParseLoopStatement()
+    {
+        Accept(TokenKind.Repeat);
+
+        if (_currentToken.Kind == TokenKind.IntLiteral)
+        {
+            string value = _currentToken.Spelling;
+            Accept(TokenKind.IntLiteral);
+            Accept(TokenKind.Times);
+            Block block = ParseBlock();
+            return new RepeatTimes(int.Parse(value), block);
+        }
+        else
+        {
+            Accept(TokenKind.Until);
+            Accept(TokenKind.LParenthesis);
+            Expression condition = ParseExpression();
+            Accept(TokenKind.RParenthesis);
+            Block block = ParseBlock();
+            return new RepeatUntil(condition, block);
+        }
+    }
+
+    private VomitStatement ParseVomitStatement()
+    {
+        Accept(TokenKind.Vomit);
+        Expression expr = ParseExpression();
+        Accept(TokenKind.Semicolon);
+        return new VomitStatement(expr);
+    }
+
+    private ListenStatement ParseListenStatement()
+    {
+        Accept(TokenKind.ListenCarefully);
+        Identifier id = ParseIdentifier();
+        Accept(TokenKind.Semicolon);
+        return new ListenStatement(id);
+    }
+
+    private SubRoutineDeclar ParseSubroutineDecl()
+    {
+        Accept(TokenKind.Sprout);
+        Identifier name = ParseIdentifier();
+        Accept(TokenKind.LParenthesis);
+
+        List<Param> parameters = new();
+        if (_currentToken.Kind != TokenKind.RParenthesis)
+        {
+            parameters.Add(ParseParam());
+            while (_currentToken.Kind == TokenKind.Comma)
+            {
+                Accept(TokenKind.Comma);
+                parameters.Add(ParseParam());
+            }
+        }
+
+        Accept(TokenKind.RParenthesis);
+        Block body = ParseBlock();
+        return new SubRoutineDeclar(name, parameters, body);
+    }
+
+    private Param ParseParam()
+    {
+        TypeSpec type = ParseType();
+        Identifier id = ParseIdentifier();
+        return new Param(type, id);
+    }
+
+    private CallStatement ParseCallStatement()
+    {
+        Accept(TokenKind.Bloom);
+        Identifier id = ParseIdentifier();
+        Accept(TokenKind.LParenthesis);
+        var args = ParseArguments();
+        Accept(TokenKind.RParenthesis);
+        Accept(TokenKind.Semicolon);
+        return new CallStatement(new CallExpr(id.Spelling, args));
+    }
+
+    private ArgList ParseArguments()
+    {
+        var args = new ArgList();
+        if (IsStarterOfExpression(_currentToken.Kind))
+        {
+            args.Arguments.Add(ParseExpression());
+            while (_currentToken.Kind == TokenKind.Comma)
+            {
+                Accept(TokenKind.Comma);
+                args.Arguments.Add(ParseExpression());
+            }
+        }
+        return args;
+    }
+
+    private Block ParseBlock()
+    {
+        Accept(TokenKind.LBrace);
+        var statements = new List<Statement>();
+        while (_currentToken.Kind != TokenKind.RBrace)
+        {
+            statements.Add(ParseOneStatement());
+        }
+        Accept(TokenKind.RBrace);
+        return new Block(statements);
+    }
+
+    private Expression ParseExpression()
+    {
+        return ParseLogicalOrExpression();
+    }
+
+
+    private Expression ParseLogicalOrExpression()
+    {
+        Expression left = ParseLogicalAndExpression();
+        
+        while (_currentToken.Kind == TokenKind.Or)
+        {
+            Accept(TokenKind.Or);
+            Expression right = ParseLogicalAndExpression();
+            left = new BinaryExpr(left, new Operator("||"), right);
+        }
+
+
+        return left;
+    }
+    
+    private Expression ParseLogicalAndExpression()
+    {
+        Expression left = ParseEqualityExpression();
+
+        while (_currentToken.Kind == TokenKind.And)
+        {
+            Accept(TokenKind.And);
+            Expression right = ParseEqualityExpression();
+            left = new BinaryExpr(left, new Operator("&&"), right);
+        }
+
+
+        return left;
+    }
+
+
+    private Expression ParseEqualityExpression()
+    {
+        Expression left = ParseRelationalExpression();
+        
+        while (_currentToken.Kind == TokenKind.Equals || _currentToken.Kind == TokenKind.NotEquals)
+        {
+            var op = _currentToken.Kind == TokenKind.Equals ? "==" : "!=";
+            Accept(_currentToken.Kind);
+            Expression right = ParseRelationalExpression();
+            left = new BinaryExpr(left, new Operator(op), right);
+        }
+        return left;
+    }
+
+
+    private Expression ParseRelationalExpression()
+    {
+        Expression left = ParseAdditiveExpression();
+
+
+        while (_currentToken.Kind == TokenKind.LessThan || _currentToken.Kind == TokenKind.GreaterThan)
+        {
+            var op = _currentToken.Kind == TokenKind.LessThan ? "<" : ">";
+            Accept(_currentToken.Kind);
+            Expression right = ParseAdditiveExpression();
+            left = new BinaryExpr(left, new Operator(op), right);
+        }
+
+        return left;
+    }
+
+    private Expression ParseAdditiveExpression()
+    {
+        Expression left = ParseMultiplicativeExpression(); // Changed from ParseUnaryExpression
+
+        while (_currentToken.Kind == TokenKind.Plus || _currentToken.Kind == TokenKind.Minus) // Changed from Multiply/Divide
+        {
+            var op = _currentToken.Kind == TokenKind.Plus ? "+" : "-";
+            Accept(_currentToken.Kind);
+            Expression right = ParseMultiplicativeExpression(); // Changed from ParseUnaryExpression
+            left = new BinaryExpr(left, new Operator(op), right);
+        }
+
+        return left;
+    }
+
+    private Expression ParseMultiplicativeExpression() // New method
+    {
+        Expression left = ParseUnaryExpression();
+
+        while (_currentToken.Kind == TokenKind.Multiply || _currentToken.Kind == TokenKind.Divide)
+        {
+            var op = _currentToken.Kind == TokenKind.Multiply ? "*" : "/";
+            Accept(_currentToken.Kind);
+            Expression right = ParseUnaryExpression();
+            left = new BinaryExpr(left, new Operator(op), right);
+        }
+
+        return left;
+    }
+
+
+    private Expression ParseUnaryExpression()
+    {
+        if (_currentToken.Kind == TokenKind.Not || _currentToken.Kind == TokenKind.Minus)
+        {
+            string op = _currentToken.Kind == TokenKind.Not ? "!" : "-";
+            Accept(_currentToken.Kind);
+            Expression right = ParseUnaryExpression();
+            return new UnaryExpr(new Operator(op), right);
+        }
+
+
+        return ParsePrimaryExpression();
+    }
+
+
+    private Expression ParsePrimaryExpression()
+    {
+        if (_currentToken.Kind == TokenKind.IntLiteral)
+        {
+            string value = _currentToken.Spelling;
+            Accept(TokenKind.IntLiteral);
+            return new IntLiteralExpression(new IntLiteral(int.Parse(value)));
+        }
+        else if (_currentToken.Kind == TokenKind.CharLiteral)
+        {
+            string value = _currentToken.Spelling;
+            Accept(TokenKind.CharLiteral);
+            return new CharLiteralExpression(new CharLiteral(char.Parse(value)));
+        }
+        else if (_currentToken.Kind == TokenKind.Identifier)
+        {
+            return ParseVariableOrFunctionCall();
+        }
+        else if (_currentToken.Kind == TokenKind.LParenthesis)
+        {
+            return ParseGroupedExpression();
+        }
+        else
+        {
+            throw new Exception($"Unexpected token in primary expression: {_currentToken.Kind}");
+        }
+    }
+
+
+    private Expression ParseVariableOrFunctionCall()
+    {
+        Identifier id = ParseIdentifier();
+
+        if (_currentToken.Kind == TokenKind.LParenthesis)
+        {
+            Accept(TokenKind.LParenthesis);
+            var args = ParseArguments();
+            Accept(TokenKind.RParenthesis);
+            return new CallExpr(id.Spelling, args);
+        }
+
+        return new VarExpression(new Identifier(id.Spelling));
+    }
+
+
+    private Expression ParseGroupedExpression()
+    {
+        Accept(TokenKind.LParenthesis);
+        Expression expr = ParseExpression();
+        Accept(TokenKind.RParenthesis);
+        return expr;
+    }
+    private TypeSpec ParseType()
+    {
+        switch (_currentToken.Kind)
+        {
+            case TokenKind.Int:
+                Accept(TokenKind.Int);
+                return new SimpleType(BaseType.Int);
+            case TokenKind.Bool:
+                Accept(TokenKind.Bool);
+                return new SimpleType(BaseType.Bool);
+            case TokenKind.Char:
+                Accept(TokenKind.Char);
+                return new SimpleType(BaseType.Char);
+            default:
+                throw new Exception($"Unexpected type: {_currentToken.Kind}");
+        }
+    }
+
+    private Identifier ParseIdentifier()
+    {
+        var name = _currentToken.Spelling;
+        Accept(TokenKind.Identifier);
+        return new Identifier(name);
+    }
+
+    private bool IsStarterOfStatement(TokenKind kind)
+    {
+        return kind is TokenKind.Create or TokenKind.Identifier or TokenKind.Si or TokenKind.Repeat or TokenKind.Vomit or TokenKind.ListenCarefully or TokenKind.Bloom or TokenKind.Sprout or TokenKind.LBrace;
+    }
+
+    private bool IsStarterOfExpression(TokenKind kind)
+    {
+        return kind is TokenKind.IntLiteral or TokenKind.CharLiteral or TokenKind.StringLiteral or TokenKind.Identifier or TokenKind.LParenthesis or TokenKind.Not or TokenKind.Minus;
+    }
+}

--- a/SproutLang/Parser/ASTViewer.cs
+++ b/SproutLang/Parser/ASTViewer.cs
@@ -26,7 +26,7 @@ public static class ASTPrinter
                 Print(assign.Expr, indent + (isLast ? "    " : "│   "), true);
                 break;
 
-            case ArrayAssigment assign:
+            case ArrayAssignment assign:
                 Console.WriteLine($"ArrayAssignment {assign.Name.Spelling}");
                 Print(assign.Index, indent + (isLast ? "    " : "│   "), true);
                 break;

--- a/SproutLang/Parser/ASTViewer.cs
+++ b/SproutLang/Parser/ASTViewer.cs
@@ -1,0 +1,62 @@
+namespace SproutLang.Tools;
+using SproutLang.AST;
+
+public static class ASTPrinter
+{
+    public static void Print(AST ast, string indent = "", bool isLast = true)
+    {
+        Console.Write(indent);
+        Console.Write(isLast ? "└── " : "├── ");
+
+        switch (ast)
+        {
+            case Block block:
+                Console.WriteLine("Block");
+                for (int i = 0; i < block.Statements.Count; i++)
+                    Print(block.Statements[i], indent + (isLast ? "    " : "│   "), i == block.Statements.Count - 1);
+                break;
+
+            case VarDecl decl:
+                Console.WriteLine($"VarDecl {decl.Name.Spelling}");
+                Print(decl.Type, indent + (isLast ? "    " : "│   "), true);
+                break;
+
+            case VarAssignment assign:
+                Console.WriteLine($"VarAssignment {assign.Name.Spelling}");
+                Print(assign.Expr, indent + (isLast ? "    " : "│   "), true);
+                break;
+
+            case ArrayAssigment assign:
+                Console.WriteLine($"ArrayAssignment {assign.Name.Spelling}");
+                Print(assign.Index, indent + (isLast ? "    " : "│   "), true);
+                break;
+
+            case BinaryExpr bin:
+                Console.WriteLine($"BinaryExpr {bin.op}");
+                Print(bin.left, indent + (isLast ? "    " : "│   "), false);
+                Print(bin.right, indent + (isLast ? "    " : "│   "), true);
+                break;
+
+            case UnaryExpr un:
+                Console.WriteLine($"UnaryExpr {un.Operator}");
+                Print(un.Operand, indent + (isLast ? "    " : "│   "), true);
+                break;
+
+            case VarExpression v:
+                Console.WriteLine($"VarRef {v.Name.Spelling}");
+                break;
+
+            case Identifier id:
+                Console.WriteLine($"Identifier \"{id.Spelling}\"");
+                break;
+
+            case SimpleType st:
+                Console.WriteLine($"SimpleType {st.Kind}");
+                break;
+
+            default:
+                Console.WriteLine(ast.GetType().Name);
+                break;
+        }
+    }
+}

--- a/SproutLang/Scanner/IScanner.cs
+++ b/SproutLang/Scanner/IScanner.cs
@@ -1,0 +1,7 @@
+namespace SproutLang.Scanner;
+
+public interface IScanner
+{ 
+    public Token Scan();
+    
+}

--- a/SproutLang/Scanner/Scanner.cs
+++ b/SproutLang/Scanner/Scanner.cs
@@ -2,7 +2,7 @@ using System.Text;
 
 namespace SproutLang.Scanner;
 
-public class Scanner
+public class Scanner : IScanner
 {
     private SourceFile _sourceFile;
     
@@ -16,7 +16,7 @@ public class Scanner
         currentChar = sourceFile.GetSource();
     }
     
-    private void takeIt()
+    private void TakeIt()
     {
         currentSpelling.Append(currentChar);
         currentChar = _sourceFile.GetSource();
@@ -27,21 +27,21 @@ public class Scanner
        switch (currentChar)
        {
            case '#':
-            takeIt();
+            TakeIt();
             while ( currentChar != SourceFile.EOL && currentChar != SourceFile.EOT )
             {
-                takeIt();
+                TakeIt();
             }
             if ( currentChar == SourceFile.EOL )
             {
-                takeIt();
+                TakeIt();
             }
             break;
            case ' ': 
            case '\n': 
            case '\r': 
            case '\t':
-               takeIt();
+               TakeIt();
                break;
        }
     }
@@ -60,10 +60,10 @@ public class Scanner
     {
         if (isLetter(currentChar))
         {
-            takeIt();
+            TakeIt();
             while ( isLetter(currentChar) || isDigit(currentChar) )
             {
-                takeIt();
+                TakeIt();
             }
 
             string spelling = currentSpelling.ToString();
@@ -77,10 +77,10 @@ public class Scanner
         }
         else if (isDigit(currentChar))
         {
-            takeIt();
+            TakeIt();
             while (isDigit(currentChar))
             {
-                takeIt();
+                TakeIt();
             }
 
             return TokenKind.IntLiteral;
@@ -89,38 +89,38 @@ public class Scanner
         switch (currentChar)
         {
             case '+':
-                takeIt();
+                TakeIt();
                 return TokenKind.Plus;
             case '-':
-                takeIt();
+                TakeIt();
                 return TokenKind.Minus;
             case '*':
-                takeIt();
+                TakeIt();
                 return TokenKind.Multiply;
             case '/':
-                takeIt();
+                TakeIt();
                 return TokenKind.Divide;
             case '=':
-                takeIt();
+                TakeIt();
                 if (currentChar == '=')
                 {
-                    takeIt();
+                    TakeIt();
                     return TokenKind.Equals;  // ==
                 }
                 return TokenKind.Assign;  // =
             case '!':
-                takeIt();
+                TakeIt();
                 if (currentChar == '=')
                 {
-                    takeIt();
+                    TakeIt();
                     return TokenKind.NotEquals;  // !=
                 }
                 return TokenKind.Not;  // !
             case '&':
-                takeIt();
+                TakeIt();
                 if (currentChar == '&')
                 {
-                    takeIt();
+                    TakeIt();
                     return TokenKind.And;  // &&
                 }
                 else
@@ -128,10 +128,10 @@ public class Scanner
                     return TokenKind.Error;
                 }
             case '|':
-                takeIt();
+                TakeIt();
                 if (currentChar == '|')
                 {
-                    takeIt();
+                    TakeIt();
                     return TokenKind.Or;  // ||
                 }
                 else
@@ -139,39 +139,39 @@ public class Scanner
                     return TokenKind.Error;
                 }
             case ',':
-                takeIt();
+                TakeIt();
                 return TokenKind.Comma;
             case ';':
-                takeIt();
+                TakeIt();
                 return TokenKind.Semicolon;
             case '(':
-                takeIt();
+                TakeIt();
                 return TokenKind.LParenthesis;
             case ')':
-                takeIt();
+                TakeIt();
                 return TokenKind.RParenthesis;
             case '[':
-                takeIt();
+                TakeIt();
                 return TokenKind.LBracket;
             case ']':
-                takeIt();
+                TakeIt();
                 return TokenKind.RBracket;
             case '{':
-                takeIt();
+                TakeIt();
                 return TokenKind.LBrace;
             case '}':
-                takeIt();
+                TakeIt();
                 return TokenKind.RBrace;
             case '<':
-                takeIt();
+                TakeIt();
                 return TokenKind.LessThan;
             case '>':
-                takeIt();
+                TakeIt();
                 return TokenKind.GreaterThan;
             case SourceFile.EOT:
                 return TokenKind.EOT;
             default:
-                takeIt();
+                TakeIt();
                 return TokenKind.Error;
         }
     }

--- a/TestProject1/UnitTests/ASTParserTests.cs
+++ b/TestProject1/UnitTests/ASTParserTests.cs
@@ -56,7 +56,7 @@ public class ASTParserTests
             Assert.Equal("x", stmt.Name.Spelling);
 
             var literal = Assert.IsType<IntLiteralExpression>(stmt.Expr);
-            Assert.Equal(42, literal.Lieteral.Value);
+            Assert.Equal(42, literal.Literal.Value);
         }
 
         [Fact]

--- a/TestProject1/UnitTests/ASTParserTests.cs
+++ b/TestProject1/UnitTests/ASTParserTests.cs
@@ -1,0 +1,162 @@
+using SproutLang.AST;
+using SproutLang.Parser;
+using SproutLang.Scanner;
+using SproutLang.Tools;
+using Xunit.Abstractions;
+
+namespace TestProject1.UnitTests;
+
+public class ASTParserTests
+{
+
+    private readonly ITestOutputHelper _testOutputHelper;
+    public ASTParserTests(ITestOutputHelper testOutputHelper)
+    {
+        _testOutputHelper = testOutputHelper;
+    }
+
+    private SproutLang.AST.Program AssertParses(string code)
+    {
+        string tempFile = Path.GetTempFileName();
+        File.WriteAllText(tempFile, code);
+        try
+        {
+            var sourceFile = new SourceFile(tempFile);
+            var scanner = new Scanner(sourceFile);
+            var parser = new ASTParser(scanner);
+            return parser.ParseProgram();
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+        public void Parse_VarDecl_ShouldBuildVarDeclNode()
+        {
+            string code = "create int x = 5;";
+            var program = AssertParses(code);
+
+            Assert.Single(program.Block.Statements);
+            var decl = Assert.IsType<VarDecl>(program.Block.Statements[0]);
+            Assert.Equal("x", decl.Name.Spelling);
+            Assert.IsType<SimpleType>(decl.Type);
+            Assert.Equal(BaseType.Int, ((SimpleType)decl.Type).Kind);
+        }
+
+        [Fact]
+        public void Parse_Assignment_ShouldBuildVarAssignment()
+        {
+            string code = "x = 42;";
+            var program = AssertParses(code);
+
+            var stmt = Assert.IsType<VarAssignment>(program.Block.Statements[0]);
+            Assert.Equal("x", stmt.Name.Spelling);
+
+            var literal = Assert.IsType<IntLiteralExpression>(stmt.Expr);
+            Assert.Equal(42, literal.Lieteral.Value);
+        }
+
+        [Fact]
+        public void Parse_IfStatement_ShouldContainConditionAndBlocks()
+        {
+            string code = "si (x > 0) { vomit x; } sino { vomit 0; }";
+            var program = AssertParses(code);
+
+            var ifStmt = Assert.IsType<IfStatement>(program.Block.Statements[0]);
+
+            Assert.IsType<BinaryExpr>(ifStmt.First.Condition);
+            Assert.NotNull(ifStmt.First.Block);
+
+            Assert.NotNull(ifStmt.ElseBlock);
+        }
+
+        [Fact]
+        public void Parse_RepeatTimes_ShouldContainTimesAndBody()
+        {
+            string code = "repeat 3 times { vomit 1; }";
+            var program = AssertParses(code);
+
+            var loop = Assert.IsType<RepeatTimes>(program.Block.Statements[0]);
+            Assert.Equal(3, loop.Times);
+            Assert.Single(loop.Body.Statements);
+        }
+
+        [Fact]
+        public void Parse_RepeatUntil_ShouldContainConditionAndBody()
+        {
+            string code = "repeat until (x < 10) { x = x + 1; }";
+            var program = AssertParses(code);
+
+            var loop = Assert.IsType<RepeatUntil>(program.Block.Statements[0]);
+            Assert.IsType<BinaryExpr>(loop.Condition);
+            Assert.Single(loop.Body.Statements);
+        }
+
+        [Fact]
+        public void Parse_Vomit_ShouldContainExpression()
+        {
+            string code = "vomit x;";
+            var program = AssertParses(code);
+
+            var stmt = Assert.IsType<VomitStatement>(program.Block.Statements[0]);
+            Assert.IsType<VarExpression>(stmt.Expression);
+        }
+
+        [Fact]
+        public void Parse_Listen_ShouldContainIdentifier()
+        {
+            string code = "listenCarefully x;";
+            var program = AssertParses(code);
+
+            var stmt = Assert.IsType<ListenStatement>(program.Block.Statements[0]);
+            Assert.Equal("x", stmt.Identifier.Spelling);
+        }
+
+        [Fact]
+        public void Parse_Subroutine_ShouldContainParametersAndBody()
+        {
+            string code = "sprout foo(int x, char y) { vomit x; }";
+            var program = AssertParses(code);
+
+            var sub = Assert.IsType<SubRoutineDeclar>(program.Block.Statements[0]);
+            Assert.Equal("foo", sub.Name.Spelling);
+            Assert.Equal(2, sub.Params.Count);
+            Assert.Single(sub.Body.Statements);
+        }
+
+        [Fact]
+        public void Parse_FunctionCall_ShouldBuildCallStatement()
+        {
+            string code = "bloom print(x, 1);";
+            var program = AssertParses(code);
+
+            var call = Assert.IsType<CallStatement>(program.Block.Statements[0]);
+            Assert.Equal("print", call.Call.Callee);
+            Assert.Equal(2, call.Call.Arguments.Arguments.Count);
+        }
+        
+        [Fact]
+        public void ASTPrinter_ShouldPrintSimpleVarDecl()
+        {
+            string code = "create int x = 5;";
+            var program = AssertParses(code);
+            
+            using var sw = new StringWriter();
+            var originalOut = Console.Out;
+            Console.SetOut(sw);
+
+            ASTPrinter.Print(program.Block);
+
+            Console.SetOut(originalOut);
+            string output = sw.ToString();
+            _testOutputHelper.WriteLine(output);
+
+            Assert.Contains("Block", output);
+            Assert.Contains("VarDecl x", output);
+            Assert.Contains("SimpleType Int", output);
+        }
+        
+}


### PR DESCRIPTION
This pull request introduces the initial implementation of the Abstract Syntax Tree (AST) for the SproutLang language. It establishes the foundational class hierarchy and defines various node types for representing language constructs such as expressions, literals, statements, and control flow. These classes will serve as the building blocks for parsing and analyzing SproutLang programs.

**Core AST infrastructure:**

* Introduced the base `AST` class and core abstract types (`AST.cs`, `Expression.cs`, `LValue.cs`). [[1]](diffhunk://#diff-73b4d38a4a483730f6a9eec58c842149cb5cc55736d08b2d6cb8e4d3a28fba5cR1-R6) [[2]](diffhunk://#diff-1028024101cc62f724ac1eae476c2aa7e5ef6016483097e1faa0130a198805caR1-R6) [[3]](diffhunk://#diff-f3d74a8995f01dc8640e1711a102c6af446ff102cc1ec9876d167cb2a87a629bR1-R6)

**Expression and literal nodes:**

* Added classes for expressions and their literal forms, including `IntLiteral`, `BoolLiteral`, `CharLiteral`, and their corresponding expression wrappers, as well as `BinaryExpr` and `CallExpr`. [[1]](diffhunk://#diff-7e9483aaae02567bbe86ca30e2d4b7e2e5916c8112927647cd09ba6bfaf30c69R1-R10) [[2]](diffhunk://#diff-fac322d9edce125d6c8f2b5ac0860372e76971439bd5ee8818fc0495065d9d49R1-R11) [[3]](diffhunk://#diff-968b5aa680b6c43363d4408039574cf922e7d5c699e2f1e80c5959348ce4fa8eR1-R11) [[4]](diffhunk://#diff-2cf657083894acd6047c2e98ea5d89436d29de77646305e09503ce5fe7becd9bR1-R10) [[5]](diffhunk://#diff-f37d467b8e63df17dea3fffeccaf7b6820573733cb3593df1da19d5eb8bf695bR1-R11) [[6]](diffhunk://#diff-66b73f95072721ddd9322e8d4a2fbc5ad1790d700ca1f99c7f78622b4ce9df65R1-R11) [[7]](diffhunk://#diff-4c9549501d9963d8407e2c7105efccea5004a5efd7c430b75e4a3ce360e0ffedR1-R14) [[8]](diffhunk://#diff-2b03128a502cb0a38d82af310926f03aa308f771030f3cca547cd649488e3436R1-R14)
* Defined the `Operator` and `BaseType` enums for use in expressions and type annotations.

**Statements and control flow:**

* Implemented statement node types, including `Block`, `Declaration`, `CallStatement`, and control flow constructs like `IfBranch` and `IfStatement`. [[1]](diffhunk://#diff-52973e7cc5bd6f661d632bad1d13890cfcb1e0be8a404b2a24921e1797a5b619R1-R12) [[2]](diffhunk://#diff-8ceabaa033c14399fca99e23c86819aa933d0bda50b4daa64b6edf44d2246e07R1-R5) [[3]](diffhunk://#diff-2a589f8c1ca63d0c8aa03b2b3bd024bf5ccee4f350753ddbfe8aa63e0d1c9335R1-R11) [[4]](diffhunk://#diff-440f210d0d6eef895ad4333abc296eb55f8dc7b08762b4a7c6b29735c6005902R1-R12) [[5]](diffhunk://#diff-26a43da01ca6530bbdcf77ea46ee3db7ab2ee7c011a6bcfff8ff1d5ff0a01670R1-R15)

**Identifiers, arguments, and assignment:**

* Added support classes for identifiers (`Identifier`), argument lists (`ArgList`), and array assignments (`ArrayAssigment`). [[1]](diffhunk://#diff-6065b17bac823b62f33c01df25389d10d238b8cb9c01b63f0755f10e93da20c8R1-R8) [[2]](diffhunk://#diff-cd28b71db1d9d711f12569e21a0b3f6aa3d7fc33e4ca67b15495c6bfdbb75b5cR1-R11) [[3]](diffhunk://#diff-e67701ff7849158dadedf027233c3532b1c8eefc7521f126fec0f3c9a63ffbafR1-R12)

This AST may need revision 